### PR TITLE
Accept absolute paths

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,8 +22,8 @@ module.exports = function(assets) {
       var relDest = opts.dest || 'public';
       var createDest = opts.createDest || true;
 
-      var src = path.join(metalsmith.directory(), relSrc);
-      var dst = path.join(metalsmith.destination(), relDest);
+      var src = path.isAbsolute(relSrc) ? relSrc : path.join(metalsmith.directory(), relSrc);
+      var dst = path.isAbsolute(relDest) ? relDest : path.join(metalsmith.destination(), relDest);
 
       if (createDest) {
         var dir = path.dirname(dst);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "debug": "~0.7.4"
   },
   "devDependencies": {
+    "assert": "^1.4.1",
+    "assert-dir-equal": "0.0.1",
+    "fs-extra": "^0.10.0",
     "metalsmith": "1.x",
-    "assert-dir-equal": "0.0.1"
+    "mocha": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "metalsmith-static",
   "repository": "git://github.com/thehydroimpulse/metalsmith-static.git",
   "author": "Daniel Fagnan",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "lib/index.js",
   "dependencies": {
     "ncp": "~0.5.0",

--- a/test/index.js
+++ b/test/index.js
@@ -66,5 +66,25 @@ describe('test', function() {
         done();
       });
   });
+
+  it('should accept absolute paths', function(done) {
+    var metalsmith = Metalsmith('test/fixtures/two');
+
+    fs.removeSync('test/fixtures/two/build/*');
+
+    metalsmith
+      .clean(false)
+      .use(asset({
+        "src": __dirname + "/fixtures/two/public",
+        "dest": __dirname + "/fixtures/two/build",
+      }))
+      .build(function(err) {
+        if (err) return done(err);
+
+        equal('test/fixtures/two/expected', 'test/fixtures/two/build');
+
+        done();
+      });
+  });
 });
 


### PR DESCRIPTION
You can now use absolute paths for `src` and `dest`. It's a non-breaking change, so existing users shouldn't notice the update.

I also added the libraries required for running the test to the devDependencies.